### PR TITLE
chore(package): add npm scripts and git commit validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,20 +1,30 @@
 {
   "name": "@motorcycle/core",
   "version": "0.1.7",
-  "description": "Cycle.js written with Most.js instead of RxJs",
+  "description": "Cycle.js with most.js reactive library instead of RxJS.",
   "main": "lib/index.js",
   "directories": {
-    "test": "test"
+    "lib": "./lib"
   },
+  "files": [
+    "lib/"
+  ],
   "scripts": {
     "eslint": "eslint src/",
     "mocha": "mocha --compilers js:babel-core/register",
     "test": "npm run eslint && npm run mocha",
-    "compile-lib": "./node_modules/.bin/babel src/ -d lib/"
+    "start": "npm install && npm prune && validate-commit-msg",
+    "precompile": "rm -rf lib/ && mkdir -p lib",
+    "compile": "babel -d lib/ src/",
+    "prepublish": "npm run compile",
+    "release": "npm run release-patch",
+    "release-patch": "git checkout master && release patch && npm publish --access=public",
+    "release-minor": "git checkout master && release minor && npm publish --access=public",
+    "release-major": "git checkout master && release major && npm publish --access=public"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Motorcycle/motorcycle-core.git"
+    "url": "https://github.com/motorcyclejs/motorcycle-core.git"
   },
   "keywords": [
     "Cyclejs",
@@ -27,9 +37,12 @@
   "author": "Tylor Steinberger <tlsteinberger167@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Motorcycle/motorcycle-core/issues"
+    "url": "https://github.com/motorcyclejs/motorcycle-core/issues"
   },
-  "homepage": "https://github.com/Motorcycle/motorcycle-core#readme",
+  "homepage": "https://github.com/motorcyclejs/motorcycle-core#readme",
+  "contributors": [
+    "Frederik Krautwald <fkrautwald@gmail.com> (https://github.com/Frikki)"
+  ],
   "peerDependencies": {
     "most": "*"
   },
@@ -39,11 +52,13 @@
     "babel-core": "^6.0.14",
     "babel-eslint": "^4.1.3",
     "babel-preset-es2015": "^6.0.14",
+    "cli-release": "^1.0.3",
     "eslint": "1.0.x",
     "eslint-config-cycle": "^3.0.0",
     "eslint-plugin-cycle": "^1.0.1",
     "eslint-plugin-no-class": "^0.1.0",
     "mocha": "^2.3.3",
-    "most": "^0.16.0"
+    "most": "^0.16.0",
+    "validate-commit-message": "^3.0.1"
   }
 }


### PR DESCRIPTION
In order to ensure consistent git commit messages,
add validate-commit-message package. The package installs a git-hook
and adds automatic changelog generation with its release script.

Add npm `start` script to make easy installation of the scripts from
the validate-commit-message package. The validation-commit-message
scripts are installed by running `npm start`.

* Add npm scripts in order to automate chore tasks:
  * rename `compile-lib` to `compile`,
  * automatic removal and creation of `lib/`, and
  * release scripts for patch, minor, and major that checks out master
    branch, bumps package version, version tags commit, updates changelog,
    compiles `lib/`, and publishes to npm.
* Fix Github links.

Closes #6
Closes #9
Closes #10