### PR TITLE
Proper handling of errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-plugin-no-class": "0.1.0",
     "mocha": "2.3.4",
     "most": "0.16.0",
+    "sinon": "^1.17.2",
     "testem": "0.9.11",
     "validate-commit-message": "3.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint-plugin-no-class": "0.1.0",
     "mocha": "2.3.4",
     "most": "0.16.0",
-    "sinon": "^1.17.2",
+    "sinon": "1.17.2",
     "testem": "0.9.11",
     "validate-commit-message": "3.0.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,9 @@ const callDrivers =
     return sources
   }
 
+const logErrorToConsole =
+  err => console.error(err.stack || err)
+
 const replicateMany =
   (sinks, sinkProxies) =>
     setTimeout(
@@ -31,7 +34,10 @@ const replicateMany =
           if (sinks.hasOwnProperty(name) &&
           sinkProxies.hasOwnProperty(name))
           {
-            sinks[name].forEach(sinkProxies[name].sink.add)
+            sinks[name]
+              .forEach(sinkProxies[name].sink.add)
+              .then(() => {})
+              .catch(logErrorToConsole)
           }
         }
       }


### PR DESCRIPTION
This is a fix for issue #24. 

Errors will now be logged to the console by `console.error()`.
At first it will attempt to log a stack trace if possible, and fallback to a
simple error message when a stack trace is unavailable.